### PR TITLE
OPT Injects messages instead of using message handler

### DIFF
--- a/src/cljs/mftickets_web/components/login_page/handlers.cljs
+++ b/src/cljs/mftickets_web/components/login_page/handlers.cljs
@@ -15,14 +15,15 @@
 
 (defn key-submit
   "handler to submit the key."
-  [{:keys [state reduce! http send-message!]}]
+  [{:keys [state reduce! http messages]}]
   (let [get-token! (:get-token http)
         key (-> state queries/key-input-state :value)
         email (-> state queries/email-input-state :value)
-        params {:keyValue key :email email}]
+        params {:keyValue key :email email}
+        update-token-msg (:update-token messages)]
     (fn []
       (reduce! (reducers/before-key-submit))
       (async/go
         (let [response (-> params get-token! async/<!)]
           (-> response reducers/after-key-submit reduce!)
-          (->> response :body :token (send-message! :update-token)))))))
+          (->> response :body :token update-token-msg))))))

--- a/src/cljs/mftickets_web/core.cljs
+++ b/src/cljs/mftickets_web/core.cljs
@@ -39,11 +39,13 @@
     :ping http/ping}
    app-state))
 
-(def message-handler
-  (messages/message-handler {:app-state app-state}))
+(def messages
+  (messages/messages-getter
+   {:update-token messages/m-update-token}
+   app-state))
 
 (def injections
-  {:app-state app-state :http http :send-message! message-handler})
+  {:app-state app-state :http http :messages messages})
 
 (defn home-page []
   (fn []

--- a/src/cljs/mftickets_web/instances/header.cljs
+++ b/src/cljs/mftickets_web/instances/header.cljs
@@ -6,10 +6,10 @@
 (defn- mk-reduce [app-state] #(swap! app-state update ::state %))
 
 (defn header-instance
-  [{:keys [app-state http send-message!]}]
+  [{:keys [app-state http messages]}]
   [components.header/header
    {:state   (get-state app-state)
     :reduce! (mk-reduce app-state)
     :http    http
-    :send-message! send-message!}])
+    :messages messages}])
 

--- a/src/cljs/mftickets_web/instances/login_page.cljs
+++ b/src/cljs/mftickets_web/instances/login_page.cljs
@@ -6,9 +6,9 @@
 (defn- mk-reduce [app-state] #(swap! app-state update ::state %))
 
 (defn login-page-instance
-  [{:keys [app-state http send-message!]}]
+  [{:keys [app-state http messages]}]
   [components.login-page/login-page
    {:state   (get-state app-state)
     :reduce! (mk-reduce app-state)
     :http    http
-    :send-message! send-message!}])
+    :messages messages}])

--- a/src/cljs/mftickets_web/messages.cljs
+++ b/src/cljs/mftickets_web/messages.cljs
@@ -2,13 +2,21 @@
   (:require
    [cljs.pprint]))
 
-(defn message-handler
-  "Returns a message handler given an application state."
-  [{:keys [app-state]}]
-  (fn a-message-handler [msg & args]
-    (cljs.pprint/pprint {:msg msg :args args})
-    (case msg
+(defn m-update-token [token] #(assoc % :token token))
 
-      :update-token
-      (let [token (first args)]
-        (swap! app-state assoc :token token)))))
+(defn messages-getter
+  "Prepares a lookable object for message functions.
+  `messages-fns` is a map where each value is a function returning a reducer.  
+  Everytime the getter returns a value, it reduces the app-state using the result
+  of calling the reducer."
+  [messages-fns app-state]
+
+  (reify
+    ILookup
+    (-lookup [this k]
+      (-lookup this k nil))
+
+    (-lookup [this k not-found]
+      (if-let [f (get messages-fns k)]
+        (fn wrapped-f [& args] (swap! app-state (apply f args)))
+        not-found))))

--- a/test/cljs/mftickets_web/messages_test.cljs
+++ b/test/cljs/mftickets_web/messages_test.cljs
@@ -1,0 +1,17 @@
+(ns mftickets-web.messages-test
+  (:require [mftickets-web.messages :as sut]
+            [cljs.test :refer-macros [is are deftest testing async use-fixtures]]))
+
+(deftest test-messages-getter
+
+  (testing "Returns nil if not found"
+    (let [messages (sut/messages-getter {} ::app-state)]
+      (is (nil? (:foo messages)))))
+
+  (testing "Runs the reducer"
+    (let [reducer (fn [x] #(assoc % ::foo x))
+          app-state (atom {})
+          messages (sut/messages-getter {:myfun reducer} app-state)]
+      ((:myfun messages) ::bar)
+      (is (= @app-state {::foo ::bar})))))
+


### PR DESCRIPTION
Messages are now injected by the `messages-getter`, which wraps
functions returning reducers into functions that apply those
reductions to the app state.