### PR TITLE
OPT Creates current page component

### DIFF
--- a/src/cljs/mftickets_web/components/current_page.cljs
+++ b/src/cljs/mftickets_web/components/current_page.cljs
@@ -1,0 +1,9 @@
+(ns mftickets-web.components.current-page)
+
+(defn current-page
+  "Renders the current page for the app."
+  [{{:keys [login-page router-dialog header page]} :current-page/instances
+    :current-page/keys [logged-in?]}]
+  (if-not logged-in?
+    login-page
+    [:<> router-dialog header [page]]))

--- a/src/cljs/mftickets_web/core.cljs
+++ b/src/cljs/mftickets_web/core.cljs
@@ -6,10 +6,8 @@
    [clerk.core :as clerk]
    [accountant.core :as accountant]
    [cljs.core.async :as async]
-   [mftickets-web.instances.login-page :as instances.login-page]
+   [mftickets-web.instances.current-page :as instances.current-page]
    [mftickets-web.instances.templates-page :as instances.templates-page]
-   [mftickets-web.instances.header :as instances.header]
-   [mftickets-web.instances.router-dialog :as instances.router-dialog]
    [mftickets-web.http :as http]))
 
 ;; -------------------------
@@ -46,12 +44,7 @@
 (def injections
   {:app-state app-state :http http})
 
-(defn home-page []
-  (fn []
-    [:div.main
-     (if-let [token (:token @app-state)]
-       [:div "You are logged in!"]
-       [instances.login-page/login-page-instance injections])]))
+(defn home-page [] [:div.main [:div "You are logged in!"]])
 
 (defn items-page []
   (fn []
@@ -90,14 +83,7 @@
 
 ;; -------------------------
 ;; Page mounting component
-(defn current-page []
-  (fn []
-    (let [page (:current-page (session/get :route))]
-      [:div
-       [instances.router-dialog/router-dialog-instance injections]
-       [:header [instances.header/header-instance injections]]
-       [page]
-       [:footer]])))
+(defn current-page [] [instances.current-page/current-page-instance injections])
 
 ;; -------------------------
 ;; Initialize app

--- a/src/cljs/mftickets_web/instances/current_page.cljs
+++ b/src/cljs/mftickets_web/instances/current_page.cljs
@@ -1,0 +1,24 @@
+(ns mftickets-web.instances.current-page
+  (:require
+   [reagent.session :as session]
+   [mftickets-web.instances.login-page :as instances.login-page]
+   [mftickets-web.instances.router-dialog :as instances.router-dialog]
+   [mftickets-web.instances.header :as instances.header]
+   [mftickets-web.components.current-page :as components.current-page]))
+
+(defn current-page-instance
+  "Instance holding the current-page component."
+  [{:keys [app-state] :as injections}]
+
+  (let [logged-in? (-> @app-state :token nil? not)
+        login-page [instances.login-page/login-page-instance injections]
+        router-dialog [instances.router-dialog/router-dialog-instance injections]
+        header [instances.header/header-instance injections]
+        page (:current-page (session/get :route))]
+
+    [components.current-page/current-page
+     #:current-page{:logged-in? logged-in?
+                    :instances {:login-page login-page
+                                :router-dialog router-dialog
+                                :header header
+                                :page page}}]))

--- a/src/sass/components/_form.scss
+++ b/src/sass/components/_form.scss
@@ -3,7 +3,6 @@
     position: relative;
 
     &__loading-div {
-        display: inline-block;
         background-color: orangered;
         opacity: 0.5;
         position: absolute;

--- a/src/sass/components/_login-page.scss
+++ b/src/sass/components/_login-page.scss
@@ -1,0 +1,4 @@
+.login-page {
+    text-align: center;
+    margin-top: 64px;
+}

--- a/src/sass/site.scss
+++ b/src/sass/site.scss
@@ -11,6 +11,7 @@
 @import 'components/life-prober';
 @import 'components/dialog';
 @import 'components/router-input';
+@import 'components/login-page';
 
 // You can use any sass features, like variables, for instance:
 $font-stack: 'Helvetica Neue', Verdana, Helvetica, Arial, sans-serif;

--- a/test/cljs/mftickets_web/components/current_page_test.cljs
+++ b/test/cljs/mftickets_web/components/current_page_test.cljs
@@ -1,0 +1,28 @@
+(ns mftickets-web.components.current-page-test
+  (:require [mftickets-web.components.current-page :as sut]
+            [cljs.test :refer-macros [is are deftest testing async use-fixtures]]))
+
+(deftest test-page
+
+  (testing "Render login page if not logged in"
+    (let [login-page [:div "Login Page"]
+          props #:current-page{:logged-in? false :instances {:login-page login-page}}]
+      (is (= login-page (sut/current-page props)))))
+
+  (testing "If logged in..."
+
+    (let [instances {:header [:header#header]
+                     :router-dialog [:div#router-dialog]
+                     :page [:div#page]}
+          props #:current-page{:logged-in? true :instances instances}
+          current-page (sut/current-page props)]
+
+      (testing "Renders header"
+        (is (= (:header instances) (get current-page 2))))
+
+      (testing "Renders router-dialog"
+        (is (= (:router-dialog instances) (get current-page 1))))
+
+      (testing "Renders page"
+        (is (= [(:page instances)] (get current-page 3)))))))
+


### PR DESCRIPTION
Adds the `current-page` component to host the current page. This
component only displayes the header if the user is already logged in.

Improves the login scss styles to fit the new structure.