### PR TITLE
REF Centralizes routing configuration and uses helper functions

### DIFF
--- a/src/cljs/cljs/test_ns_requires.cljs
+++ b/src/cljs/cljs/test_ns_requires.cljs
@@ -73,5 +73,6 @@
 [mftickets-web.domain.template-property-test]
 [mftickets-web.domain.template-section-test]
 [mftickets-web.http-test]
+[mftickets-web.routing-test]
 [mftickets-web.state-test]
 ))

--- a/src/cljs/mftickets_web/app/queries.cljs
+++ b/src/cljs/mftickets_web/app/queries.cljs
@@ -22,3 +22,8 @@
     (if (nil? active-project-id*)
       (first projects*)
       (s/select-first [s/ALL #(= (:id %) active-project-id*)] projects*))))
+
+(defn current-routing-match
+  "The current routing match, as a reitit match."
+  [x]
+  (:current-routing-match x))

--- a/src/cljs/mftickets_web/app/reducers.cljs
+++ b/src/cljs/mftickets_web/app/reducers.cljs
@@ -33,3 +33,4 @@
   #(assoc % :token new-token))
 
 (defn set-active-project-id [x] #(assoc % :active-project-id x))
+(defn set-current-routing-match [x] #(assoc % :current-routing-match x))

--- a/src/cljs/mftickets_web/components/current_page.cljs
+++ b/src/cljs/mftickets_web/components/current_page.cljs
@@ -3,7 +3,7 @@
 (defn current-page
   "Renders the current page for the app."
   [{{:keys [login-page router-dialog header page]} :current-page/instances
-    :current-page/keys [logged-in?]}]
+    :current-page/keys [logged-in? injections]}]
   (if-not logged-in?
     login-page
-    [:<> router-dialog header [page]]))
+    [:<> router-dialog header [page injections]]))

--- a/src/cljs/mftickets_web/instances/current_page.cljs
+++ b/src/cljs/mftickets_web/instances/current_page.cljs
@@ -4,7 +4,9 @@
    [mftickets-web.instances.login-page :as instances.login-page]
    [mftickets-web.instances.router-dialog :as instances.router-dialog]
    [mftickets-web.instances.header :as instances.header]
-   [mftickets-web.components.current-page :as components.current-page]))
+   [mftickets-web.components.current-page :as components.current-page]
+   [mftickets-web.routing :as routing]
+   [mftickets-web.app.queries :as queries]))
 
 (defn current-page-instance
   "Instance holding the current-page component."
@@ -14,10 +16,11 @@
         login-page [instances.login-page/login-page-instance injections]
         router-dialog [instances.router-dialog/router-dialog-instance injections]
         header [instances.header/header-instance injections]
-        page (:current-page (session/get :route))]
+        page (-> @app-state queries/current-routing-match routing/route-match->component)]
 
     [components.current-page/current-page
      #:current-page{:logged-in? logged-in?
+                    :injections injections
                     :instances {:login-page login-page
                                 :router-dialog router-dialog
                                 :header header

--- a/src/cljs/mftickets_web/instances/router_dialog.cljs
+++ b/src/cljs/mftickets_web/instances/router_dialog.cljs
@@ -4,25 +4,13 @@
    [mftickets-web.components.dialog :as components.dialog]
    [mftickets-web.components.router-input :as components.router-input]
    [mftickets-web.state :as state]
-   [mftickets-web.app.handlers :as handlers]))
-
-;; !!!! TODO -> Give real options
-(def options
-  [{:label "Templates" :href "/templates"}
-   {:label "Templates - View [Templates]" :href "/templates/view"}
-   {:label "Templates - Edit [Templates]" :href "/templates/edit"}
-   {:label "Projects" :href "/projects"}
-   {:label "Projects - Edit [Projects]" :href "/projects/edit"}
-   {:label "Projects - Create [Projects]" :href "/projects/create"}
-   {:label "Projects - View [Projects]" :href "/projects/view"}
-   {:label "About" :href "/about"}
-   {:label "Home" :href "/"}
-   {:label "Configurations [Options]" :href "/config"}])
+   [mftickets-web.app.handlers :as handlers]
+   [mftickets-web.routing :as routing]))
 
 (defn router-dialog-instance
-  [{:keys [app-state http] :as inject}]
+  [{:keys [app-state http router] :as inject}]
   [components.router-dialog/router-dialog
-   {:router-dialog/options options
+   {:router-dialog/options (routing/router->user-routing-opts router)
     :router-dialog.messages/close-router-dialog #(handlers/close-router-dialog inject)
     :router-dialog.messages/navigate #(handlers/navigate inject %)
     :state      (state/->FocusedAtom app-state [::state])

--- a/src/cljs/mftickets_web/routing.cljs
+++ b/src/cljs/mftickets_web/routing.cljs
@@ -1,0 +1,16 @@
+(ns mftickets-web.routing
+  (:require [reitit.core]
+            [reitit.frontend]))
+
+(defn route-match->component
+  [route-match]
+  {:pre [(instance? reitit.core/Match route-match)]}
+  (some-> route-match :data :component))
+
+(defn router->user-routing-opts
+  "Takes a reitit router and parses it into a list of routes that a user can select and
+  navigate to."
+  [router]
+  {:pre [(satisfies? reitit.core/Router router)]}
+  (for [[_ {label :label name :name} _] (reitit.core/compiled-routes router)]
+    {:label label :href (->> name (reitit.frontend/match-by-name router) :path)}))

--- a/test/cljs/mftickets_web/app/queries_test.cljs
+++ b/test/cljs/mftickets_web/app/queries_test.cljs
@@ -49,3 +49,8 @@
           state (-> {} ((reducers/set-app-metadata-response {:success true
                                                              :body {:projects projects}})))]
       (is (= (first projects) (sut/active-project state))))))
+
+(deftest test-current-routing-match
+  (let [current-match {:path "foo"}
+        state (-> {} ((reducers/set-current-routing-match current-match)))]
+    (is (= current-match (sut/current-routing-match state)))))

--- a/test/cljs/mftickets_web/components/current_page_test.cljs
+++ b/test/cljs/mftickets_web/components/current_page_test.cljs
@@ -14,7 +14,8 @@
     (let [instances {:header [:header#header]
                      :router-dialog [:div#router-dialog]
                      :page [:div#page]}
-          props #:current-page{:logged-in? true :instances instances}
+          injections {::foo 1}
+          props #:current-page{:logged-in? true :instances instances :injections injections}
           current-page (sut/current-page props)]
 
       (testing "Renders header"
@@ -24,5 +25,5 @@
         (is (= (:router-dialog instances) (get current-page 1))))
 
       (testing "Renders page"
-        (is (= [(:page instances)] (get current-page 3)))))))
+        (is (= [(:page instances) injections] (get current-page 3)))))))
 

--- a/test/cljs/mftickets_web/routing_test.cljs
+++ b/test/cljs/mftickets_web/routing_test.cljs
@@ -1,0 +1,16 @@
+(ns mftickets-web.routing-test
+  (:require [mftickets-web.routing :as sut]
+            [cljs.test :refer-macros [is are deftest testing async use-fixtures]]
+            [reitit.frontend]))
+
+(deftest test-router->user-routing-opts
+  (let [path1 "/foo"
+        label1 "Foo"
+        route1 [path1 {:name :foo :label label1}]
+        path2 "/bar"
+        label2 "Bar"
+        route2 [path2 {:name :bar :label label2}]
+        routes [route1 route2]
+        router (reitit.frontend/router routes)]
+    (is (= [{:label label1 :href path1} {:label label2 :href path2}]
+           (sut/router->user-routing-opts router)))))


### PR DESCRIPTION
Moves all routing configuration to 'mftickets-web.core/router, and all
routing state to the 'app-state. Uses helper functions to retrieve the
user routing options and the current page from the app state and from
the injected route on instances.