### PR TITLE
REF Uses dynamic registration of components that can act like input

### DIFF
--- a/src/cljs/mftickets_web/components/factories/input.cljs
+++ b/src/cljs/mftickets_web/components/factories/input.cljs
@@ -5,6 +5,7 @@
 
 ;; Specs
 (spec/def :factories.input/component ifn?)
+(spec/def :factories.input/component-kw keyword?)
 (spec/def :factories.input/assoc-disabled? ifn?)
 (spec/def :factories.input/disabled? (spec/or :boolean boolean? :nil nil?))
 (spec/def :factories.input/id keyword)
@@ -13,13 +14,23 @@
 (spec/def :factories.input/assoc-value-to-props-fn ifn?)
 
 (spec/def :factories/input
-  (spec/keys
-   :req [:factories.input/component
-         :factories.input/assoc-disabled?
-         :factories.input/id
-         :factories.input/focus-value-fn
-         :factories.input/update-value-fn
-         :factories.input/assoc-value-to-props-fn]))
+  (spec/and
+   (spec/keys
+    :req [:factories.input/component-kw
+          :factories.input/id
+          :factories.input/focus-value-fn
+          :factories.input/update-value-fn])))
+
+;; Multimethods
+(defmulti input-factory-opts
+  "Main registration for components that can behave like inputs.
+  This method must return a map with:
+  - `factories.input/component`: The component that will be used.
+  - `factories.input/assoc-disabled?`: Receives props and a boolean value and set's the the
+       component to be disabled.
+  - `factories.input/assoc-value-to-props-fn`: A function that accepts a props that will be
+       passed to the `component` and assocs the focused value to it."
+  (fn [component-kw] component-kw))
 
 ;; Factories
 (defn input-factory
@@ -30,19 +41,16 @@
   - `parent-value`: The current value being displayed.
   
   Recognizes the following keys in metadata:
-  - `factories.input/component`: The component that will be used.
-  - `factories.input/assoc-disabled?`: Receives props and a boolean value and set's the the
-       component to be disabled.
+  - `factories.input/component-kw`: The kw representing the component to render. Will be
+       given to the `input-factory-opts` multimethod.
   - `factories.input/disabled?`: Whether input is disabled or not.
   - `factories.input/id`: An unique id, used as react key.
   - `factories.input/focus-value-fn`: A function that focus on an specific part of the parent
        value that will be passed to the child component.
   - `factories.input/update-value-fn`: A function accepting the old parent value and the new
-       user input and updates it.
-  - `factories.input/assoc-value-to-props-fn`: A function that accepts a props that will be
-       passed to the `component` and assocs the focused value to it."
-  [{:factories.input/keys [component id focus-value-fn assoc-value-to-props-fn assoc-disabled?
-                           disabled?]
+       user input and updates it."
+  [{:factories.input/keys [component-kw component id focus-value-fn assoc-value-to-props-fn
+                           assoc-disabled? disabled?]
     :or {disabled? nil}
     :as metadata}
    parent-value]
@@ -50,10 +58,20 @@
   {:pre [(spec/assert :factories/input metadata)
          (do (spec/assert :factories.input/disabled? disabled?) true)]}
 
-  (let [value (focus-value-fn parent-value)
-        props (cond-> metadata
-                :always (assoc-value-to-props-fn value)
-                (not (nil? disabled?)) (assoc-disabled? disabled?))]
+  (let [{:factories.input/keys [component assoc-value-to-props-fn assoc-disabled?]}
+        (input-factory-opts component-kw)
+
+        _ (spec/assert :factories.input/component component)
+        _ (spec/assert :factories.input/assoc-disabled? assoc-disabled?)
+        _ (spec/assert :factories.input/assoc-value-to-props-fn assoc-value-to-props-fn)
+        
+        value
+        (focus-value-fn parent-value)
+
+        props
+        (cond-> metadata
+          :always (assoc-value-to-props-fn value)
+          (not (nil? disabled?)) (assoc-disabled? disabled?))]
 
     ^{:key id}
     [component props]))

--- a/src/cljs/mftickets_web/components/input.cljs
+++ b/src/cljs/mftickets_web/components/input.cljs
@@ -2,7 +2,8 @@
   (:require
    [mftickets-web.components.input.handlers :as handlers]
    [reagent.core :as r]
-   [cljs.spec.alpha :as spec]))
+   [cljs.spec.alpha :as spec]
+   [mftickets-web.components.factories.input :as factories.input]))
 
 (def base-input-wrapper-class "input-wrapper")
 (def base-html-input-class "input-wrapper__input")
@@ -38,3 +39,8 @@
   [:div {:class base-input-wrapper-class}
    [label-span label]
    [html-input props]])
+
+(defmethod factories.input/input-factory-opts ::input [_]
+  {:factories.input/component input
+   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
+   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)})

--- a/src/cljs/mftickets_web/components/project_form/inputs.cljs
+++ b/src/cljs/mftickets_web/components/project_form/inputs.cljs
@@ -5,10 +5,8 @@
 
 ;; Metadata
 (def id
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
-
+  {:factories.input/component-kw ::components.input/input
+   
    :factories.input/id :id
    :factories.input/focus-value-fn :id
    :factories.input/update-value-fn #(assoc %1 :id %2)
@@ -18,9 +16,7 @@
    :input/disabled true})
 
 (def name
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
+  {:factories.input/component-kw ::components.input/input
 
    :factories.input/id :name
    :factories.input/focus-value-fn :name
@@ -30,9 +26,7 @@
    :input/label "Name"})
 
 (def description
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
+  {:factories.input/component-kw ::components.input/input
 
    :factories.input/id :description
    :factories.input/focus-value-fn :description

--- a/src/cljs/mftickets_web/components/select.cljs
+++ b/src/cljs/mftickets_web/components/select.cljs
@@ -4,7 +4,8 @@
    ["react-select" :default Select]
    ["react-select/async" :default AsyncSelect]
    [cljs.spec.alpha :as s]
-   [mftickets-web.components.select.handlers :as handlers]))
+   [mftickets-web.components.select.handlers :as handlers]
+   [mftickets-web.components.factories.input :as factories.input]))
 
 (def base-class "select")
 (def base-label-class "select__label")
@@ -69,6 +70,11 @@
       :options options
       :on-change #(handlers/on-change props %)
       :isDisabled disabled}]]])
+
+(defmethod factories.input/input-factory-opts ::select [_]
+  {:factories.input/component select
+   :factories.input/assoc-disabled? #(assoc %1 :select/disabled %2)
+   :factories.input/assoc-value-to-props-fn #(assoc %1 :select/value %2)})
 
 (defn async-select
   "A wrapper around ReactSelect Async."

--- a/src/cljs/mftickets_web/components/template_form.cljs
+++ b/src/cljs/mftickets_web/components/template_form.cljs
@@ -33,7 +33,7 @@
 (defn- render-input
   "Renders an input given the for props and input metadta."
   [{:template-form/keys [edited-template] :as props}
-   {:factories.input/keys [events-mapping] :as metadata}]
+   metadata]
 
   {:pre [(spec/assert :factories/input metadata)
          (spec/assert :template-form/props props)]}

--- a/src/cljs/mftickets_web/components/template_form/inputs.cljs
+++ b/src/cljs/mftickets_web/components/template_form/inputs.cljs
@@ -7,9 +7,7 @@
 
 ;; Metadata
 (def id
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
+  {:factories.input/component-kw ::components.input/input
    
    :factories.input/id :id
    :factories.input/focus-value-fn :id
@@ -20,9 +18,7 @@
    :input/disabled true})
 
 (def name
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
+  {:factories.input/component-kw ::components.input/input
 
    :factories.input/id :name
    :factories.input/focus-value-fn :name
@@ -32,9 +28,7 @@
    :input/label "Name"})
 
 (def project-id
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
+  {:factories.input/component-kw ::components.input/input
 
    :factories.input/id :project-id
    :factories.input/focus-value-fn :project-id
@@ -44,9 +38,7 @@
    :input/label "Project Id"})
 
 (def creation-date
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
+  {:factories.input/component-kw ::components.input/input
 
    :factories.input/id :creation-date
    :factories.input/focus-value-fn :creation-date
@@ -57,18 +49,13 @@
    :input/disabled true})
 
 (def sections-actions-buttons
-  {:factories.input/component #'sections-actions-buttons/template-form-sections-actions-buttons
-   :factories.input/assoc-disabled? #(do %1)
+  {:factories.input/component-kw ::sections-actions-buttons/template-form-sections-actions-buttons
    :factories.input/id :sections-actions-buttons
    :factories.input/focus-value-fn #(do nil)
-   :factories.input/update-value-fn #(do %1)
-   :factories.input/assoc-value-to-props-fn #(do %1)})
+   :factories.input/update-value-fn #(do %1)})
 
 (def sections
-  {:factories.input/component #'components.template-sections-form/template-sections-form
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :template-sections-form/sections %2)
-   :factories.input/assoc-disabled? #(assoc %1 :template-sections-form/disabled %2)
-   
+  {:factories.input/component-kw ::components.template-sections-form/template-sections-form
    :factories.input/id :sections
    :factories.input/focus-value-fn :sections
    :factories.input/update-value-fn #(assoc %1 :sections %2)})

--- a/src/cljs/mftickets_web/components/template_form/sections_actions_buttons.cljs
+++ b/src/cljs/mftickets_web/components/template_form/sections_actions_buttons.cljs
@@ -1,5 +1,6 @@
 (ns mftickets-web.components.template-form.sections-actions-buttons
-  (:require [mftickets-web.components.button :as components.button]))
+  (:require [mftickets-web.components.button :as components.button]
+            [mftickets-web.components.factories.input :as factories.input]))
 
 ;; Globals
 (def ^:private add-section-label "Add Section")
@@ -20,3 +21,8 @@
   [props]
   [:div {:class [base-class]}
    [add-button props]])
+
+(defmethod factories.input/input-factory-opts ::template-form-sections-actions-buttons [_]
+  {:factories.input/component template-form-sections-actions-buttons
+   :factories.input/assoc-disabled? #(do %1)
+   :factories.input/assoc-value-to-props-fn #(do %1)})

--- a/src/cljs/mftickets_web/components/template_properties_form.cljs
+++ b/src/cljs/mftickets_web/components/template_properties_form.cljs
@@ -3,7 +3,8 @@
             [mftickets-web.components.factories.input :as factories.input]
             [mftickets-web.components.template-properties-form.input :as input]
             [mftickets-web.components.template-properties-form.handlers :as handlers]
-            [mftickets-web.domain.template-property :as domain.template-property]))
+            [mftickets-web.domain.template-property :as domain.template-property]
+            [mftickets-web.components.factories.input :as factories.input]))
 
 ;; Css
 (def base-class "template-properties-form")
@@ -68,3 +69,8 @@
                 id (domain.template-property/get-id property)]]
       ^{:key id}
       [property-input props*])]])
+
+(defmethod factories.input/input-factory-opts ::template-properties-form [_]
+  {:factories.input/component template-properties-form
+   :factories.input/assoc-disabled? #(assoc %1 :template-properties-form/disabled %2)
+   :factories.input/assoc-value-to-props-fn #(assoc %1 :template-properties-form/properties %2)})

--- a/src/cljs/mftickets_web/components/template_properties_form/actions_buttons.cljs
+++ b/src/cljs/mftickets_web/components/template_properties_form/actions_buttons.cljs
@@ -1,5 +1,6 @@
 (ns mftickets-web.components.template-properties-form.actions-buttons
-  (:require [mftickets-web.components.button :as components.button]))
+  (:require [mftickets-web.components.button :as components.button]
+            [mftickets-web.components.factories.input :as factories.input]))
 
 ;; Css
 (def ^:private base-class "template-properties-form-actions-buttons")
@@ -18,3 +19,8 @@
 (defn template-properties-form-actions-buttons [props]
   [:div {:class base-class}
    [remove-button props]])
+
+(defmethod factories.input/input-factory-opts ::template-properties-form-actions-buttons [_]
+  {:factories.input/component template-properties-form-actions-buttons
+   :factories.input/assoc-disabled? #(do %1)
+   :factories.input/assoc-value-to-props-fn #(do %1)})

--- a/src/cljs/mftickets_web/components/template_properties_form/input.cljs
+++ b/src/cljs/mftickets_web/components/template_properties_form/input.cljs
@@ -7,10 +7,7 @@
   (:refer-clojure :exclude [name]))
 
 (def id
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-
+  {:factories.input/component-kw ::components.input/input
    :factories.input/id :id
    :factories.input/focus-value-fn :id
    :factories.input/update-value-fn #(assoc %1 :id %2)
@@ -19,10 +16,7 @@
    :input/disabled true})
 
 (def name
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-
+  {:factories.input/component-kw ::components.input/input
    :factories.input/id :name
    :factories.input/focus-value-fn :name
    :factories.input/update-value-fn #(assoc %1 :name %2)
@@ -30,10 +24,7 @@
    :input/label "Name"})
 
 (def is-multiple
-  {:factories.input/component #'components.select/select
-   :factories.input/assoc-disabled? #(assoc %1 :select/disabled %2)
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :select/value %2)
-
+  {:factories.input/component-kw ::components.select/select
    :factories.input/id :is-multiple
    :factories.input/focus-value-fn #(some-> % :is-multiple domain.select/boolean->option)
    :factories.input/update-value-fn (fn [property is-multiple-option]
@@ -47,10 +38,7 @@
    :select/label-wrapper-class components.input/base-input-wrapper-label-class})
 
 (def value-type
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-   
+  {:factories.input/component-kw ::components.input/input
    :factories.input/id :value-type
    :factories.input/focus-value-fn :value-type
    :factories.input/update-value-fn #(assoc %1 :value-type %2)
@@ -58,10 +46,7 @@
    :input/label "Type"})
 
 (def actions-buttons
-  {:factories.input/component #'actions-buttons/template-properties-form-actions-buttons
-   :factories.input/assoc-disabled? #(do %1)
-   :factories.input/assoc-value-to-props-fn #(do %1)
-
+  {:factories.input/component-kw ::actions-buttons/template-properties-form-actions-buttons
    :factories.input/id :actions-buttons
    :factories.input/focus-value-fn #(do nil)
    :factories.input/update-value-fn #(do nil)})

--- a/src/cljs/mftickets_web/components/template_sections_form.cljs
+++ b/src/cljs/mftickets_web/components/template_sections_form.cljs
@@ -4,7 +4,8 @@
             [mftickets-web.components.template-sections-form.input :as input]
             [mftickets-web.components.factories.input :as factories.input]
             [mftickets-web.components.template-sections-form.handlers :as handlers]
-            [mftickets-web.domain.template-section :as template-section]))
+            [mftickets-web.domain.template-section :as template-section]
+            [mftickets-web.components.factories.input :as factories.input]))
 
 ;; Scss
 (def base-class "template-sections-form")
@@ -71,3 +72,8 @@
           :let [id (template-section/get-id section)]]
       ^{:key id}
       [section-input (assoc props :template-sections-form.impl/section section)])]])
+
+(defmethod factories.input/input-factory-opts ::template-sections-form [_]
+  {:factories.input/component template-sections-form
+   :factories.input/assoc-value-to-props-fn #(assoc %1 :template-sections-form/sections %2)
+   :factories.input/assoc-disabled? #(assoc %1 :template-sections-form/disabled %2)})

--- a/src/cljs/mftickets_web/components/template_sections_form/actions_buttons.cljs
+++ b/src/cljs/mftickets_web/components/template_sections_form/actions_buttons.cljs
@@ -1,5 +1,6 @@
 (ns mftickets-web.components.template-sections-form.actions-buttons
-  (:require [mftickets-web.components.button :as components.button]))
+  (:require [mftickets-web.components.button :as components.button]
+            [mftickets-web.components.factories.input :as factories.input]))
 
 ;; Scss
 (def base-class "template-section-form-action-buttons")
@@ -36,3 +37,8 @@
   [:div {:class base-class}
    [remove-button props]
    [add-property-button props]])
+
+(defmethod factories.input/input-factory-opts ::template-section-form-action-buttons [_]
+  {:factories.input/component template-section-form-action-buttons
+   :factories.input/assoc-disabled? #(do %1)
+   :factories.input/assoc-value-to-props-fn #(do %1)})

--- a/src/cljs/mftickets_web/components/template_sections_form/input.cljs
+++ b/src/cljs/mftickets_web/components/template_sections_form/input.cljs
@@ -7,10 +7,7 @@
 
 ;; Metadata
 (def id
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-
+  {:factories.input/component-kw ::components.input/input
    :factories.input/id :id
    :factories.input/focus-value-fn :id
    :factories.input/update-value-fn #(assoc %1 :id %2)
@@ -19,10 +16,7 @@
    :input/disabled true})
 
 (def name
-  {:factories.input/component #'components.input/input
-   :factories.input/assoc-disabled? #(assoc %1 :input/disabled %2)
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :input/value %2)
-
+  {:factories.input/component-kw ::components.input/input
    :factories.input/id :name
    :factories.input/focus-value-fn :name
    :factories.input/update-value-fn #(assoc %1 :name %2)
@@ -30,19 +24,13 @@
    :input/label "Name"})
 
 (def actions-buttons
-  {:factories.input/component #'actions-buttons/template-section-form-action-buttons
-   :factories.input/assoc-disabled? #(do %1)
-   :factories.input/assoc-value-to-props-fn #(do %1)
-
+  {:factories.input/component-kw ::actions-buttons/template-section-form-action-buttons
    :factories.input/id :actions-buttons
    :factories.input/focus-value-fn #(do nil)
    :factories.input/update-value-fn #(do nil)})
 
 (def properties
-  {:factories.input/component #'components.template-properties-form/template-properties-form
-   :factories.input/assoc-disabled? #(assoc %1 :template-properties-form/disabled %2)
-   :factories.input/assoc-value-to-props-fn #(assoc %1 :template-properties-form/properties %2)
-
+  {:factories.input/component-kw ::components.template-properties-form/template-properties-form
    :factories.input/id :properties
    :factories.input/focus-value-fn :properties
    :factories.input/update-value-fn #(assoc %1 :properties %2)})

--- a/test/cljs/mftickets_web/components/factories/input_test.cljs
+++ b/test/cljs/mftickets_web/components/factories/input_test.cljs
@@ -4,20 +4,23 @@
 
 (deftest test-input-factory
 
-  (let [metadata {:factories.input/component ::component
-                  :factories.input/assoc-disabled? #(assoc %1 ::disabled %2)
+  (let [component-opts {:factories.input/component ::component
+                        :factories.input/assoc-disabled? #(assoc %1 ::disabled %2)
+                        :factories.input/assoc-value-to-props-fn #(assoc %1 ::value %2)}
+        metadata {:factories.input/component-kw ::component-kw
                   :factories.input/disabled? true
-                  :factories.input/id 999
+                  :factories.input/id :aaa
                   :factories.input/focus-value-fn ::foo
-                  :factories.input/update-value-fn #(assoc %1 ::foo %2)
-                  :factories.input/assoc-value-to-props-fn #(assoc %1 ::value %2)}
+                  :factories.input/update-value-fn #(assoc %1 ::foo %2)}
         parent-value {::foo 888}]
+
+    (defmethod sut/input-factory-opts ::component-kw [_] component-opts)
 
     (testing "Returns component"
       (is (= ::component (-> (sut/input-factory metadata parent-value) first))))
 
     (testing "Component has key equal id in metadata"
-      (is (= 999 (-> (sut/input-factory metadata parent-value) meta :key))))
+      (is (= :aaa (-> (sut/input-factory metadata parent-value) meta :key))))
 
     (testing "Value is assoc"
       (is (= 888

--- a/test/cljs/mftickets_web/components/project_form_test.cljs
+++ b/test/cljs/mftickets_web/components/project_form_test.cljs
@@ -1,32 +1,38 @@
 (ns mftickets-web.components.project-form-test
   (:require [mftickets-web.components.project-form :as sut]
             [cljs.test :refer-macros [is are deftest testing async use-fixtures]]
-            [mftickets-web.components.input :as components.input]))
+            [mftickets-web.components.input :as components.input]
+            [mftickets-web.components.factories.input :as factories.input]))
 
 (deftest test-render-input
 
-  (let [edited-project {:id 1 :name "Foo"}
-        props {:project-form/edited-project edited-project}
-        metadata {:factories.input/component :div
-                  :factories.input/id 1
-                  :factories.input/focus-value-fn (constantly ::foo)
-                  :factories.input/update-value-fn (constantly ::bar)
-                  :factories.input/assoc-value-to-props-fn #(assoc %1 ::boz %2)
-                  :div/disabled true}
-        result (sut/render-input props metadata)
-        [result-component result-props] result]
+  (let [component-opts {:factories.input/component :div
+                        :factories.input/assoc-value-to-props-fn #(assoc %1 ::boz %2)
+                        :factories.input/assoc-disabled? #(assoc %1 ::disabled %2)}]
 
-    (testing "Returns components"
-      (is (= result-component :div)))
+    (defmethod factories.input/input-factory-opts ::foo [_] component-opts)
 
-    (testing "New props are superset of old props"
-      (is (every? (fn [[k v]] (= v (get result-props k))) metadata)))
+    (let [edited-project {:id 1 :name "Foo"}
+          props {:project-form/edited-project edited-project}
+          metadata {:factories.input/component-kw ::foo
+                    :factories.input/id 1
+                    :factories.input/focus-value-fn (constantly ::foo)
+                    :factories.input/update-value-fn (constantly ::bar)
+                    :div/disabled true}
+          result (sut/render-input props metadata)
+          [result-component result-props] result]
 
-    (testing "On change message is assoced."
-      (is (fn? (:input.messages/on-change result-props))))
+      (testing "Returns components"
+        (is (= result-component :div)))
 
-    (testing "Value is assoced"
-      (is (= ::foo (::boz result-props))))))
+      (testing "New props are superset of old props"
+        (is (every? (fn [[k v]] (= v (get result-props k))) metadata)))
+
+      (testing "On change message is assoced."
+        (is (fn? (:input.messages/on-change result-props))))
+
+      (testing "Value is assoced"
+        (is (= ::foo (::boz result-props)))))))
 
 (deftest test-props->form-props
 

--- a/test/cljs/mftickets_web/components/template_form_test.cljs
+++ b/test/cljs/mftickets_web/components/template_form_test.cljs
@@ -2,28 +2,34 @@
   (:require [mftickets-web.components.template-form :as sut]
             [cljs.test :refer-macros [is are deftest testing async use-fixtures]]
             [mftickets-web.components.template-form.inputs :as inputs]
-            [mftickets-web.components.form :as components.form]))
+            [mftickets-web.components.form :as components.form]
+            [mftickets-web.components.factories.input :as factories.input]))
 
 (deftest test-render-input
 
-  (let [edited-template {:name "Foo"}
-        props {:template-form/edited-template edited-template}
-        metadata {:factories.input/component ::component
-                  :factories.input/id ::id
-                  :factories.input/focus-value-fn :name
-                  :factories.input/update-value-fn #(assoc %1 :name %2)
-                  :factories.input/assoc-value-to-props-fn #(assoc %1 :value %2)}
-        result (sut/render-input props metadata)
-        [r-component r-props] result]
+  (let [component-opts {:factories.input/component ::component
+                        :factories.input/assoc-disabled? #(assoc %1 ::disabled %2)
+                        :factories.input/assoc-value-to-props-fn #(assoc %1 :value %2)}]
+    
+    (defmethod factories.input/input-factory-opts ::foo [_] component-opts)
 
-    (testing "Renders the component"
-      (is (= ::component r-component)))
+    (let [edited-template {:name "Foo"}
+          props {:template-form/edited-template edited-template}
+          metadata {:factories.input/component-kw ::foo
+                    :factories.input/id ::id
+                    :factories.input/focus-value-fn :name
+                    :factories.input/update-value-fn #(assoc %1 :name %2)}
+          result (sut/render-input props metadata)
+          [r-component r-props] result]
 
-    (testing "Assocs the value to the props"
-      (is (= "Foo" (:value r-props))))
+      (testing "Renders the component"
+        (is (= ::component r-component)))
 
-    (testing "Passes all metadata as props"
-      (is (every? (fn [[k v]] (= (get r-props k) v)) metadata)))))
+      (testing "Assocs the value to the props"
+        (is (= "Foo" (:value r-props))))
+
+      (testing "Passes all metadata as props"
+        (is (every? (fn [[k v]] (= (get r-props k) v)) metadata))))))
 
 (deftest test-template-form
 

--- a/test/cljs/mftickets_web/components/template_sections_form_test.cljs
+++ b/test/cljs/mftickets_web/components/template_sections_form_test.cljs
@@ -1,30 +1,36 @@
 (ns mftickets-web.components.template-sections-form-test
   (:require [mftickets-web.components.template-sections-form :as sut]
-            [cljs.test :refer-macros [is are deftest testing async use-fixtures]]))
+            [cljs.test :refer-macros [is are deftest testing async use-fixtures]]
+            [mftickets-web.components.factories.input :as factories.input]))
 
 (deftest test-render-input
 
-  (let [section {:id 1}
-        props {:template-sections-form.impl/section section}
-        metadata {:factories.input/component ::div
-                  :factories.input/id ::id
-                  :factories.input/focus-value-fn :id
-                  :factories.input/update-value-fn #(assoc %1 :id %2)
-                  :factories.input/assoc-value-to-props-fn #(assoc %1 :value %2)}
-        result (sut/render-input props metadata)
-        [r-component r-props] result]
+  (let [component-opts {:factories.input/component ::div
+                        :factories.input/assoc-disabled? #(assoc %1 ::disabled %2)
+                        :factories.input/assoc-value-to-props-fn #(assoc %1 :value %2)}]
 
-    (testing "Renders the component"
-      (is (= r-component ::div)))
+    (defmethod factories.input/input-factory-opts ::component [_] component-opts)
 
-    (testing "Assocs the value to the props"
-      (is (= 1 (:value r-props))))
+    (let [section {:id 1}
+          props {:template-sections-form.impl/section section}
+          metadata {:factories.input/component-kw ::component
+                    :factories.input/id ::id
+                    :factories.input/focus-value-fn :id
+                    :factories.input/update-value-fn #(assoc %1 :id %2)}
+          result (sut/render-input props metadata)
+          [r-component r-props] result]
 
-    (testing "Assocs :input.messages/on-change"
-      (is (ifn? (:input.messages/on-change r-props))))
+      (testing "Renders the component"
+        (is (= r-component ::div)))
 
-    (testing "Assocs :template-sections-form.action-buttons.messages/on-remove-section"
-      (is (ifn? (:template-sections-form.action-buttons.messages/on-remove-section r-props))))
+      (testing "Assocs the value to the props"
+        (is (= 1 (:value r-props))))
 
-    (testing "Passes all metadata as props"
-      (is (every? (fn [[k v]] (= (get r-props k) v)) metadata)))))
+      (testing "Assocs :input.messages/on-change"
+        (is (ifn? (:input.messages/on-change r-props))))
+
+      (testing "Assocs :template-sections-form.action-buttons.messages/on-remove-section"
+        (is (ifn? (:template-sections-form.action-buttons.messages/on-remove-section r-props))))
+
+      (testing "Passes all metadata as props"
+        (is (every? (fn [[k v]] (= (get r-props k) v)) metadata))))))


### PR DESCRIPTION
Adds a new multimethod `input-factory-opts` which allows components to
register themselves as input-compatible and implement the interface to
act like an input. This allows `input-factory` to be passed only the
component registered kw and being able to render it properly.