### PR TITLE
NEW Uses on-key-down instead of on-key-up

### DIFF
--- a/src/cljs/mftickets_web/components/button.cljs
+++ b/src/cljs/mftickets_web/components/button.cljs
@@ -31,5 +31,5 @@
    [:div {:class (get-button-css-class props)
           :tabIndex 0
           :on-click (fn [&_] (on-click))
-          :on-key-up #(when (-> % .-key (= "Enter")) (on-click))}
+          :on-key-down #(when (-> % .-key (= "Enter")) (on-click))}
     label]])

--- a/src/cljs/mftickets_web/components/input.cljs
+++ b/src/cljs/mftickets_web/components/input.cljs
@@ -18,18 +18,18 @@
 
 (defn html-input
   "An input html component."
-  [{:input/keys [value disabled id on-key-up autofocus]
+  [{:input/keys [value disabled id on-key-down autofocus]
     :as props}]
   (r/create-class
    {:component-did-update
     #(when autofocus (.focus (r/dom-node %)))
     
     :reagent-render
-    (fn [{:input/keys [value disabled id on-key-up] :as props}]
+    (fn [{:input/keys [value disabled id on-key-down] :as props}]
       [:input
        {:class base-html-input-class
         :on-change #(handlers/on-html-input-change props %)
-        :on-key-up #(handlers/on-key-up props %)
+        :on-key-down #(handlers/on-key-down props %)
         :value (or value "")
         :disabled (or disabled false)}])}))
 

--- a/src/cljs/mftickets_web/components/input/handlers.cljs
+++ b/src/cljs/mftickets_web/components/input/handlers.cljs
@@ -1,9 +1,9 @@
 (ns mftickets-web.components.input.handlers)
 
-(defn on-key-up
-  [{:input.messages/keys [on-key-up]} event]
-  {:pre [(or (nil? on-key-up) (fn? on-key-up))]}
-  (when on-key-up (-> event .-key on-key-up)))
+(defn on-key-down
+  [{:input.messages/keys [on-key-down]} event]
+  {:pre [(or (nil? on-key-down) (fn? on-key-down))]}
+  (when on-key-down (-> event .-key on-key-down)))
 
 (defn on-html-input-change
   [{:input.messages/keys [on-change]} event]

--- a/src/cljs/mftickets_web/components/router_input.cljs
+++ b/src/cljs/mftickets_web/components/router_input.cljs
@@ -47,7 +47,7 @@
    {:input/value (queries/input-value @state)
     :input/autofocus true
     :input.messages/on-change #(handlers/on-input-change props %)
-    :input.messages/on-key-up #(handlers/on-input-key-up props %)}])
+    :input.messages/on-key-down #(handlers/on-input-key-down props %)}])
 
 (defn- option-el
   "An element representing an option inside an options list."

--- a/src/cljs/mftickets_web/components/router_input/handlers.cljs
+++ b/src/cljs/mftickets_web/components/router_input/handlers.cljs
@@ -6,11 +6,11 @@
 (defn on-input-change [{:keys [state]} new-value]
   (swap! state (reducers/set-input-value new-value)))
 
-(defn- on-arrow-input-key-up
+(defn- on-arrow-input-key-down
   [{:keys [state] :router-input/keys [matching-options]} key]
   (swap! state (reducers/select-from-key matching-options key)))
 
-(defn- on-enter-input-key-up*
+(defn- on-enter-input-key-down*
   [{:router-input.messages/keys [navigate close-router-dialog]
     :router-input/keys [selected-option]}
    key]
@@ -19,10 +19,10 @@
     [[navigate (-> selected-option :href)]
      [close-router-dialog]]))
 
-(defn- on-enter-input-key-up [props key]
-  (doseq [[fn & args] (on-enter-input-key-up* props key)]
+(defn- on-enter-input-key-down [props key]
+  (doseq [[fn & args] (on-enter-input-key-down* props key)]
     (apply fn args)))
 
-(defn on-input-key-up [props key]
-  (on-arrow-input-key-up props key)
-  (on-enter-input-key-up props key))
+(defn on-input-key-down [props key]
+  (on-arrow-input-key-down props key)
+  (on-enter-input-key-down props key))

--- a/test/cljs/mftickets_web/components/input/handlers_test.cljs
+++ b/test/cljs/mftickets_web/components/input/handlers_test.cljs
@@ -2,17 +2,17 @@
   (:require [mftickets-web.components.input.handlers :as sut]
             [cljs.test :refer-macros [is are deftest testing async use-fixtures]]))
 
-(deftest test-on-key-up
+(deftest test-on-key-down
 
   (let [event (clj->js {:key "KEY"})]
 
     (testing "With handler defined"
-      (let [on-key-up (fn [x] [::on-key-up x])
-            props {:input.messages/on-key-up on-key-up}]
-        (is (= [::on-key-up "KEY"] (sut/on-key-up props event)))))
+      (let [on-key-down (fn [x] [::on-key-down x])
+            props {:input.messages/on-key-down on-key-down}]
+        (is (= [::on-key-down "KEY"] (sut/on-key-down props event)))))
 
     (testing "No handler"
-      (is (nil? (sut/on-key-up {} event))))))
+      (is (nil? (sut/on-key-down {} event))))))
 
 (deftest test-on-html-input-change
 

--- a/test/cljs/mftickets_web/components/router_input/handlers_test.cljs
+++ b/test/cljs/mftickets_web/components/router_input/handlers_test.cljs
@@ -10,7 +10,7 @@
     (sut/on-input-change {:state state} new-value)
     (is (= e-new-state @state))))
 
-(deftest on-arrow-input-key-up
+(deftest on-arrow-input-key-down
 
   (testing "Reducers state using select-from-key"
     (let [state (atom {})
@@ -18,10 +18,10 @@
           props {:state state :router-input/matching-options matching-options}
           key "ArrowDown"
           e-state (-> @state ((reducers/select-from-key matching-options key)))]
-      (sut/on-arrow-input-key-up props key)
+      (sut/on-arrow-input-key-down props key)
       (is (= @state e-state)))))
 
-(deftest on-enter-input-key-up
+(deftest on-enter-input-key-down
 
   (let [navigate ::navigate
         close-router-dialog ::close-router-dialog
@@ -31,8 +31,8 @@
                :router-input/selected-option selected-option}]
 
     (testing "No effects when key is not enter"
-      (is (nil? (sut/on-enter-input-key-up* props "NOT ENTER"))))
+      (is (nil? (sut/on-enter-input-key-down* props "NOT ENTER"))))
 
     (testing "Calls navigate and close router dialog if it is enter"
       (is (= [[navigate "foo"] [close-router-dialog]]
-             (sut/on-enter-input-key-up* props "Enter"))))))
+             (sut/on-enter-input-key-down* props "Enter"))))))


### PR DESCRIPTION
This allows us to open the router dialog with `Enter` key, since the
on-key-down event is not passed to the dialog (only the on key up).